### PR TITLE
Add a MKSTREAM option when creating Redis consumer groups.

### DIFF
--- a/sea-streamer-redis/src/consumer/mod.rs
+++ b/sea-streamer-redis/src/consumer/mod.rs
@@ -49,6 +49,7 @@ pub struct RedisConsumerOptions {
     auto_claim_idle: Duration,
     batch_size: usize,
     shard_ownership: ShardOwnership,
+    mkstream: bool 
 }
 
 #[derive(Debug)]

--- a/sea-streamer-redis/src/consumer/node.rs
+++ b/sea-streamer-redis/src/consumer/node.rs
@@ -451,24 +451,24 @@ impl Node {
                     AutoStreamReset::Earliest => "0",
                     AutoStreamReset::Latest => DOLLAR,
                 };
-                if self.options.mkstream { 
-                    let result: Result<Value, _> = conn
+                let result: Result<Value, _> = if self.options.mkstream { 
+                    conn
                         .xgroup_create_mkstream(
                             &shard.key,
                             &self.group.group_id,
                             id,
                         )
-                        .await;
+                        .await
                 } else {
-                    let result: Result<Value, _> = conn
+                    conn
                         .xgroup_create(
                             &shard.key,
                             &self.group.group_id,
                             id,
                         )
-                        .await;
-                }
-                
+                        .await
+                };
+
                 match result {
                     Ok(_) => (),
                     Err(err) => {

--- a/sea-streamer-redis/src/consumer/options.rs
+++ b/sea-streamer-redis/src/consumer/options.rs
@@ -124,22 +124,6 @@ impl ConsumerOptions for RedisConsumerOptions {
         self.group_id = Some(group_id);
         Ok(self)
     }
-
-    /// By default, an `XGROUP CREATE <key> <groupname> <id or $>` command will be used to establish
-    /// connection to the stream as part of a consumer group.
-    /// If the stream key does not already exist, the consumer will fail to initialize. 
-    /// 
-    /// By setting this to `true`, a `XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]` command will
-    /// be used instead, allowing the consumer to initialize before the stream may be created 
-    /// by the producer calling XADD when it first enqueues a message in the stream.
-    fn set_mkstream(&mut self, enabled: bool) -> RedisResult<&mut Self> {
-        self.mkstream = enabled;
-        Ok(self)
-    }
-
-    fn mkstream(&self) -> RedisResult<bool> {
-        Ok(self.mkstream)
-    }
 }
 
 impl RedisConsumerOptions {
@@ -260,6 +244,22 @@ impl RedisConsumerOptions {
     pub fn set_shard_ownership(&mut self, shard_ownership: ShardOwnership) -> &mut Self {
         self.shard_ownership = shard_ownership;
         self
+    }
+
+    /// By default, an `XGROUP CREATE <key> <groupname> <id or $>` command will be used to establish
+    /// connection to the stream as part of a consumer group.
+    /// If the stream key does not already exist, the consumer will fail to initialize. 
+    /// 
+    /// By setting this to `true`, a `XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]` command will
+    /// be used instead, allowing the consumer to initialize before the stream may be created 
+    /// by the producer calling XADD when it first enqueues a message in the stream.
+    pub fn set_mkstream(&mut self, enabled: bool) -> RedisResult<&mut Self> {
+        self.mkstream = enabled;
+        Ok(self)
+    }
+
+    pub fn mkstream(&self) -> RedisResult<bool> {
+        Ok(self.mkstream)
     }
 
     /// Whether to pre-fetch the next page as the consumer is streaming, which results in less jitter.

--- a/sea-streamer-redis/src/consumer/options.rs
+++ b/sea-streamer-redis/src/consumer/options.rs
@@ -82,6 +82,7 @@ impl ConsumerOptions for RedisConsumerOptions {
                 DEFAULT_BATCH_SIZE
             },
             shard_ownership: ShardOwnership::Shared,
+            mkstream: false
         }
     }
 
@@ -122,6 +123,22 @@ impl ConsumerOptions for RedisConsumerOptions {
     fn set_consumer_group(&mut self, group_id: ConsumerGroup) -> RedisResult<&mut Self> {
         self.group_id = Some(group_id);
         Ok(self)
+    }
+
+    /// By default, an `XGROUP CREATE <key> <groupname> <id or $>` command will be used to establish
+    /// connection to the stream as part of a consumer group.
+    /// If the stream key does not already exist, the consumer will fail to initialize. 
+    /// 
+    /// By setting this to `true`, a `XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]` command will
+    /// be used instead, allowing the consumer to initialize before the stream may be created 
+    /// by the producer calling XADD when it first enqueues a message in the stream.
+    fn set_mkstream(&mut self, enabled: bool) -> RedisResult<&mut Self> {
+        self.mkstream = enabled;
+        Ok(self)
+    }
+
+    fn mkstream(&self) -> RedisResult<bool> {
+        Ok(self.mkstream)
     }
 }
 

--- a/sea-streamer-redis/src/consumer/options.rs
+++ b/sea-streamer-redis/src/consumer/options.rs
@@ -246,18 +246,20 @@ impl RedisConsumerOptions {
         self
     }
 
-    /// By default, an `XGROUP CREATE <key> <groupname> <id or $>` command will be used to establish
-    /// connection to the stream as part of a consumer group.
-    /// If the stream key does not already exist, the consumer will fail to initialize. 
+    /// If set to `false`, a `XGROUP CREATE <key> <groupname> <id or $>` command will be used create consumer 
+    /// groups on the stream.
+    /// If the stream key does not already exist, the command will fail and the consumer will fail to initialize. 
     /// 
-    /// By setting this to `true`, a `XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]` command will
-    /// be used instead, allowing the consumer to initialize before the stream may be created 
-    /// by the producer calling XADD when it first enqueues a message in the stream.
+    /// Setting this to `true` will cause the consumer to run 
+    /// `XGROUP CREATE <key> <groupname> <id or $> MKSTREAM` commands when first getting new messages,
+    /// allowing the consumer to initialize even if a producer has never written a message 
+    /// to a stream at the same key.
     pub fn set_mkstream(&mut self, enabled: bool) -> RedisResult<&mut Self> {
         self.mkstream = enabled;
         Ok(self)
     }
 
+    /// Default is `false`.
     pub fn mkstream(&self) -> RedisResult<bool> {
         Ok(self.mkstream)
     }


### PR DESCRIPTION
Adds a boolean option to control if the `MKSTREAM` is present in `XGROUP CREATE <key> <groupname> <id or $> [MKSTREAM]` when creating Redis consumer groups. This happens when the consumer performs its first read.

<!--

Thank you for contributing to this project!

If you need any help please feel free to contact us on Discord: https://discord.com/invite/uCPdDXzbdv
Or, mention our core members by typing `@GitHub_Handle` on any issue / PR

Add some test cases! It help reviewers to understand the behaviour and prevent it to be broken in the future.

-->

## PR Info

<!-- mention the related issue -->
- Closes <!-- issue link --> (I have gone ahead and created this PR without first opening an issue. I think the change is relatively minor and this PR can do without one. If you believe otherwise, I can create one and link it here.)

<!-- is this PR depends on other PR? (if applicable) -->
- Dependencies: None
  - <!-- PR link -->

<!-- any PR depends on this PR? (if applicable) -->
- Dependents: None
  - <!-- PR link -->

## New Features
Adds the ability for Redis consumers to create consumer groups without the stream already existing. 
This is useful for us because we may start a producer and a consumer separately when doing local development, and would prefer to avoid making sure that the producer writes first before we can run the consumer the first time.

- [ ] <!-- what are the new features? -->

## Bug Fixes

- [ ] <!-- if it fixes a bug, please provide a brief analysis of the original bug -->

## Breaking Changes

- [ ] <!-- any change in behaviour or method signature? is it backward compatible? -->

## Changes

- [ ] Add function `RedisConsumerOptions::mkstream(&self) -> RedisResult<bool>`
- [ ] Add function `RedisConsumerOptions::set_mkstream(&mut  self, enabled:bool) -> RedisResult<&mut Self>`

I am unsure if you would prefer that an enum be used for the config option instead of a `bool`, or if the comments need further workshoping. I couldn't think of good names for the enum variants, so I opted for using a `bool`. Any suggestions welcome.
