### PR TITLE
Support producing a FutureRecord for Kafka

### DIFF
--- a/sea-streamer-kafka/src/producer.rs
+++ b/sea-streamer-kafka/src/producer.rs
@@ -4,9 +4,10 @@ use crate::{
     cluster::cluster_uri, impl_into_string, stream_err, BaseOptionKey, KafkaConnectOptions,
     KafkaErr, KafkaResult, DEFAULT_TIMEOUT,
 };
+pub use rdkafka::producer::FutureRecord;
 use rdkafka::{
     config::ClientConfig,
-    producer::{DeliveryFuture, FutureRecord as RawPayload, Producer as ProducerTrait},
+    producer::{DeliveryFuture, Producer as ProducerTrait},
 };
 pub use rdkafka::{consumer::ConsumerGroupMetadata, TopicPartitionList};
 use sea_streamer_runtime::spawn_blocking;
@@ -88,7 +89,7 @@ impl Producer for KafkaProducer {
     fn send_to<S: Buffer>(&self, stream: &StreamKey, payload: S) -> KafkaResult<Self::SendFuture> {
         let fut = self
             .get()
-            .send_result(RawPayload::<str, [u8]>::to(stream.name()).payload(payload.as_bytes()))
+            .send_result(FutureRecord::<str, [u8]>::to(stream.name()).payload(payload.as_bytes()))
             .map_err(|(err, _raw)| stream_err(err))?;
 
         Ok(SendFuture {
@@ -134,11 +135,8 @@ impl KafkaProducer {
             .expect("Producer is still inside a transaction, please await the future")
     }
 
-    /// Send a record to a stream
-    pub fn send_record<K, P>(
-        &self,
-        record: rdkafka::producer::FutureRecord<K, P>,
-    ) -> KafkaResult<SendFuture>
+    /// Send a `FutureRecord` to a stream
+    pub fn send_record<K, P>(&self, record: FutureRecord<K, P>) -> KafkaResult<SendFuture>
     where
         K: rdkafka::message::ToBytes + ?Sized,
         P: rdkafka::message::ToBytes + ?Sized,

--- a/sea-streamer-kafka/tests/consumer.rs
+++ b/sea-streamer-kafka/tests/consumer.rs
@@ -51,7 +51,6 @@ async fn main() -> anyhow::Result<()> {
             .partition(0)
             .payload(&payload);
         let receipt = producer.send_record(record)?.await?;
-        println!("Receipt: {:?}", receipt);
         assert_eq!(receipt.stream_key(), &topic);
         assert_eq!(receipt.sequence(), &i);
         assert_eq!(receipt.shard_id(), &zero);
@@ -114,6 +113,15 @@ async fn main() -> anyhow::Result<()> {
     // this should continue from 7
     assert_eq!(seq, [7, 8, 9]);
     println!("Seek stream ... ok");
+
+    let seq = consume(&mut consumer, 10).await;
+    // this should continue from 10
+    assert_eq!(seq, [10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+    println!("Resume ... ok");
+
+    // commit up to 19
+    consumer.commit(&topic, &zero, &19).await?;
+    println!("Commit ... ok");
 
     async fn consume(consumer: &mut KafkaConsumer, num: usize) -> Vec<usize> {
         consumer


### PR DESCRIPTION
This PR is based on the discussion in https://github.com/SeaQL/sea-streamer/discussions/16

The current `send` functionality doesn't allow for specifying the key, partition, or headers for Kafka messages. This PR adds a `send_record` function that allows for specifying a [`FutureRecord`](https://docs.rs/rdkafka/0.36.0/rdkafka/producer/struct.FutureRecord.html) directly so that the user can customize the message.

@tyt2y3 I'm not 100% sure that this is exactly what you were looking for, but I think it's close. Let me know what you think.