### PR TITLE
Migrate to clap

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here is a basic [stream consumer](https://github.com/SeaQL/sea-streamer/tree/mai
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 
@@ -76,7 +76,7 @@ Here is a basic [stream producer](https://github.com/SeaQL/sea-streamer/tree/mai
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 
@@ -105,7 +105,7 @@ See also other [advanced stream processors](https://github.com/SeaQL/sea-streame
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = SeaStreamer::connect(input.streamer(), Default::default()).await?;
     let options = SeaConsumerOptions::new(ConsumerMode::RealTime);

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1" }
 async-std = { version = "1", features = ["attributes"], optional = true }
 env_logger = { version = "0.9" }
 flume = { version = "0.10", default-features = false, features = ["async"] }
-structopt = { version = "0.3" }
+clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.10", features = ["full"], optional = true }
 
 [dependencies.sea-streamer]

--- a/benchmark/src/bin/baseline.rs
+++ b/benchmark/src/bin/baseline.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use sea_streamer::{runtime::sleep, StreamUrl};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `kafka://localhost:9092/my_topic`",
         env = "STREAM_URL"
@@ -18,7 +18,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
     std::hint::black_box(stream);
 
     for i in 0..100_000 {

--- a/benchmark/src/bin/consumer.rs
+++ b/benchmark/src/bin/consumer.rs
@@ -3,11 +3,11 @@ use sea_streamer::{
     Buffer, Consumer, ConsumerMode, ConsumerOptions, Message, SeaConsumer, SeaConsumerOptions,
     SeaMessage, SeaStreamReset, SeaStreamer, StreamUrl, Streamer,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`",
         env = "STREAM_URL"
@@ -20,7 +20,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 

--- a/benchmark/src/bin/producer.rs
+++ b/benchmark/src/bin/producer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use sea_streamer::{Producer, SeaProducer, SeaStreamer, StreamUrl, Streamer};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `kafka://localhost:9092/my_topic`",
         env = "STREAM_URL"
@@ -18,7 +18,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 

--- a/benchmark/src/bin/relay.rs
+++ b/benchmark/src/bin/relay.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use sea_streamer::stdio::StdioStreamer;
 use sea_streamer::{Consumer, Message, Producer, StreamKey, Streamer, StreamerUri};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream key of input")]
+    #[clap(long, help = "Stream key of input")]
     input: StreamKey,
-    #[structopt(long, help = "Stream key of output")]
+    #[clap(long, help = "Stream key of output")]
     output: StreamKey,
 }
 
@@ -15,7 +15,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = StdioStreamer::connect(StreamerUri::zero(), Default::default()).await?;
     let consumer = streamer

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { version = "1" }
 async-std = { version = "1", features = ["attributes"], optional = true }
 env_logger = { version = "0.9" }
 flume = { version = "0.10", default-features = false, features = ["async"] }
-structopt = { version = "0.3" }
+clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1.10", features = ["full"], optional = true }
 
 [dependencies.sea-streamer]

--- a/examples/src/bin/blocking.rs
+++ b/examples/src/bin/blocking.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use flume::bounded;
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
 use sea_streamer::{
     runtime::{sleep, spawn_task},
@@ -9,14 +9,14 @@ use sea_streamer::{
     SeaConsumerOptions, SeaMessage, SeaProducer, SeaStreamer, SharedMessage, StreamUrl, Streamer,
 };
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`"
     )]
     input: StreamUrl,
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `stdio:///my_stream`"
     )]
@@ -30,7 +30,7 @@ const NUM_THREADS: usize = 4; // Every one has at least 2 cores with 2 hyperthre
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     // The queue
     let (sender, receiver) = bounded(1024);

--- a/examples/src/bin/buffered.rs
+++ b/examples/src/bin/buffered.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use flume::bounded;
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
 use sea_streamer::{
     runtime::{sleep, spawn_task},
@@ -9,14 +9,14 @@ use sea_streamer::{
     SeaConsumerOptions, SeaMessage, SeaProducer, SeaStreamer, SharedMessage, StreamUrl, Streamer,
 };
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`"
     )]
     input: StreamUrl,
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `stdio:///my_stream`"
     )]
@@ -28,7 +28,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     // The queue
     let (sender, receiver) = bounded(1024);

--- a/examples/src/bin/consumer.rs
+++ b/examples/src/bin/consumer.rs
@@ -3,11 +3,11 @@ use sea_streamer::{
     Buffer, Consumer, ConsumerMode, ConsumerOptions, Message, SeaConsumer, SeaConsumerOptions,
     SeaMessage, SeaStreamReset, SeaStreamer, StreamUrl, Streamer,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`",
         env = "STREAM_URL"
@@ -20,7 +20,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 

--- a/examples/src/bin/processor.rs
+++ b/examples/src/bin/processor.rs
@@ -3,16 +3,16 @@ use sea_streamer::{
     Buffer, Consumer, ConsumerMode, ConsumerOptions, Message, Producer, SeaConsumer,
     SeaConsumerOptions, SeaMessage, SeaProducer, SeaStreamer, StreamUrl, Streamer,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`"
     )]
     input: StreamUrl,
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `stdio:///my_stream`"
     )]
@@ -24,7 +24,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = SeaStreamer::connect(input.streamer(), Default::default()).await?;
     let options = SeaConsumerOptions::new(ConsumerMode::RealTime);

--- a/examples/src/bin/producer.rs
+++ b/examples/src/bin/producer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use sea_streamer::{Producer, SeaProducer, SeaStreamer, StreamUrl, Streamer};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `kafka://localhost:9092/my_topic`",
         env = "STREAM_URL"
@@ -18,7 +18,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 

--- a/examples/src/bin/resumable.rs
+++ b/examples/src/bin/resumable.rs
@@ -7,18 +7,18 @@ use sea_streamer::{
     Streamer,
 };
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
 const TRANSACTION: bool = true;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/my_topic`"
     )]
     input: StreamUrl,
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `stdio:///my_stream`"
     )]
@@ -30,7 +30,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = SeaStreamer::connect(input.streamer(), Default::default()).await?;
     let mut options = SeaConsumerOptions::new(ConsumerMode::Resumable);

--- a/sea-streamer-file/Cargo.toml
+++ b/sea-streamer-file/Cargo.toml
@@ -28,7 +28,7 @@ sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime", features = ["file"]}
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
-structopt = { version = "0.3", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.10.0", optional = true }
 
@@ -37,7 +37,7 @@ tokio = { version = "1.10.0", optional = true }
 [features]
 default = []
 test = ["anyhow", "async-std?/attributes", "tokio?/full", "env_logger"]
-executables = ["anyhow", "tokio/full", "env_logger", "structopt", "sea-streamer-runtime/runtime-tokio", "serde", "serde_json", "sea-streamer-types/serde"]
+executables = ["anyhow", "tokio/full", "env_logger", "clap", "sea-streamer-runtime/runtime-tokio", "serde", "serde_json", "sea-streamer-types/serde"]
 runtime-async-std = ["async-std", "sea-streamer-runtime/runtime-async-std"]
 runtime-tokio = ["tokio", "sea-streamer-runtime/runtime-tokio"]
 

--- a/sea-streamer-file/src/bin/clock.rs
+++ b/sea-streamer-file/src/bin/clock.rs
@@ -2,13 +2,13 @@ use anyhow::{anyhow, Result};
 use sea_streamer_file::{FileId, FileStreamer};
 use sea_streamer_types::{Producer, StreamKey, Streamer};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream to this file")]
+    #[clap(long, help = "Stream to this file")]
     file: FileId,
-    #[structopt(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
+    #[clap(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
     interval: Duration,
 }
 
@@ -28,7 +28,7 @@ fn parse_duration(src: &str) -> Result<Duration> {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { file, interval } = Args::from_args();
+    let Args { file, interval } = Args::parse();
 
     let stream_key = StreamKey::new("clock")?;
     let streamer = FileStreamer::connect(file.to_streamer_uri()?, Default::default()).await?;

--- a/sea-streamer-file/src/bin/decoder.rs
+++ b/sea-streamer-file/src/bin/decoder.rs
@@ -21,15 +21,15 @@ use sea_streamer_file::{
 };
 use sea_streamer_types::{Buffer, Message, TIMESTAMP_FORMAT};
 use std::str::FromStr;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(long, help = "Decode this file")]
+    #[clap(long, help = "Decode this file")]
     file: FileId,
-    #[structopt(long, help = "If set, skip printing the payload")]
+    #[clap(long, help = "If set, skip printing the payload")]
     header_only: bool,
-    #[structopt(long, help = "The output format", default_value = "log")]
+    #[clap(long, help = "The output format", default_value = "log")]
     format: Format,
 }
 
@@ -46,7 +46,7 @@ async fn main() -> Result<()> {
         file,
         header_only,
         format,
-    } = Args::from_args();
+    } = Args::parse();
 
     let mut source = MessageSource::new(file, StreamMode::Replay).await?;
 

--- a/sea-streamer-file/src/bin/sink.rs
+++ b/sea-streamer-file/src/bin/sink.rs
@@ -2,13 +2,13 @@ use anyhow::{anyhow, Result};
 use sea_streamer_file::{FileId, MessageSink, DEFAULT_BEACON_INTERVAL, DEFAULT_FILE_SIZE_LIMIT};
 use sea_streamer_types::{MessageHeader, OwnedMessage, ShardId, StreamKey, Timestamp};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream to this file")]
+    #[clap(long, help = "Stream to this file")]
     file: FileId,
-    #[structopt(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
+    #[clap(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
     interval: Duration,
 }
 
@@ -28,7 +28,7 @@ fn parse_duration(src: &str) -> Result<Duration> {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { file, interval } = Args::from_args();
+    let Args { file, interval } = Args::parse();
     let mut sink = MessageSink::new(
         file.clone(),
         DEFAULT_BEACON_INTERVAL,

--- a/sea-streamer-file/src/bin/tail.rs
+++ b/sea-streamer-file/src/bin/tail.rs
@@ -1,11 +1,11 @@
 //! A for demo `tail -f` program.
 use anyhow::Result;
 use sea_streamer_file::{FileId, FileSource, ReadFrom};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "File path")]
+    #[clap(long, help = "File path")]
     file: FileId,
 }
 
@@ -13,7 +13,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { file } = Args::from_args();
+    let Args { file } = Args::parse();
     let mut stream = FileSource::new(file, ReadFrom::End).await?;
 
     loop {

--- a/sea-streamer-kafka/Cargo.toml
+++ b/sea-streamer-kafka/Cargo.toml
@@ -24,14 +24,14 @@ mac_address = { version = "1" }
 rdkafka = { version = "0.29", default-features = false, features = ["libz"] }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime" }
-structopt = { version = "0.3", optional = true }
+clap = { version = "4.5", features = ["derive", "env"], optional = true }
 tokio = { version = "1.10.0", optional = true }
 
 [dev-dependencies]
 
 [features]
 test = ["anyhow", "async-std?/attributes", "tokio?/full", "env_logger"]
-executables = ["anyhow", "env_logger", "structopt", "runtime-tokio", "tokio/full"]
+executables = ["anyhow", "env_logger", "clap", "runtime-tokio", "tokio/full"]
 runtime-async-std = ["async-std", "sea-streamer-runtime/runtime-async-std"]
 runtime-tokio = ["tokio", "rdkafka/tokio", "sea-streamer-runtime/runtime-tokio"]
 # passthru of rdkafka features

--- a/sea-streamer-kafka/src/bin/consumer.rs
+++ b/sea-streamer-kafka/src/bin/consumer.rs
@@ -3,11 +3,11 @@ use sea_streamer_kafka::{AutoOffsetReset, KafkaConsumerOptions, KafkaStreamer};
 use sea_streamer_types::{
     Buffer, Consumer, ConsumerMode, ConsumerOptions, Message, StreamUrl, Streamer,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key(s), i.e. try `kafka://localhost:9092/hello`",
         env = "STREAM_URL"
@@ -19,7 +19,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = KafkaStreamer::connect(stream.streamer(), Default::default()).await?;
     let mut options = KafkaConsumerOptions::new(ConsumerMode::RealTime);

--- a/sea-streamer-kafka/src/bin/producer.rs
+++ b/sea-streamer-kafka/src/bin/producer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use sea_streamer_kafka::KafkaStreamer;
 use sea_streamer_types::{Producer, StreamUrl, Streamer};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `kafka://localhost:9092/hello`",
         env = "STREAM_URL"
@@ -17,7 +17,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = KafkaStreamer::connect(stream.streamer(), Default::default()).await?;
     let producer = streamer

--- a/sea-streamer-redis/Cargo.toml
+++ b/sea-streamer-redis/Cargo.toml
@@ -26,7 +26,7 @@ mac_address = { version = "1" }
 redis = { version = "0.22", default-features = false, features = ["acl", "streams"] }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime" }
-structopt = { version = "0.3", optional = true }
+clap = { version = "4.5", features = ["derive", "env"], optional = true }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.10.0", optional = true }
 
@@ -35,7 +35,7 @@ tokio = { version = "1.10.0", optional = true }
 [features]
 default = ["runtime-tokio"] # sadly redis does not compile without a runtime
 test = ["anyhow", "async-std?/attributes", "tokio?/full", "env_logger"]
-executables = ["anyhow", "env_logger", "structopt", "runtime-tokio", "tokio/full"]
+executables = ["anyhow", "env_logger", "clap", "runtime-tokio", "tokio/full"]
 runtime-async-std = ["async-std", "redis/async-std-comp", "sea-streamer-runtime/runtime-async-std"]
 runtime-tokio = ["tokio", "redis/tokio-comp", "sea-streamer-runtime/runtime-tokio"]
 runtime-async-std-native-tls = ["runtime-async-std", "redis/async-std-tls-comp"]

--- a/sea-streamer-redis/redis-streams-dump/Cargo.toml
+++ b/sea-streamer-redis/redis-streams-dump/Cargo.toml
@@ -18,7 +18,7 @@ log = { version = "0.4", default-features = false }
 sea-streamer-file = { version = "0.3", path = "../../sea-streamer-file", features = ["runtime-tokio"] }
 sea-streamer-redis = { version = "0.3", path = "../../sea-streamer-redis", features = ["runtime-tokio"] }
 sea-streamer-types = { version = "0.3.1", path = "../../sea-streamer-types" }
-structopt = { version = "0.3" }
+clap = { version = "4.5", features = ["derive"] }
 time = { version = "0.3", default-features = false, features = ["std", "parsing"] }
 tokio = { version = "1.10.0", features = ["full"]}
 

--- a/sea-streamer-redis/redis-streams-dump/src/main.rs
+++ b/sea-streamer-redis/redis-streams-dump/src/main.rs
@@ -6,21 +6,21 @@ use sea_streamer_types::{
     TIMESTAMP_FORMAT,
 };
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 use time::PrimitiveDateTime;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `redis://localhost/hello`"
     )]
     stream: StreamUrl,
-    #[structopt(long, help = "Output file. Overwrites if exist")]
+    #[clap(long, help = "Output file. Overwrites if exist")]
     output: FileId,
-    #[structopt(long, help = "Timestamp start of range")]
+    #[clap(long, help = "Timestamp start of range")]
     since: Option<String>,
-    #[structopt(long, help = "Timestamp end of range")]
+    #[clap(long, help = "Timestamp end of range")]
     until: Option<String>,
 }
 
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         output,
         since,
         until,
-    } = Args::from_args();
+    } = Args::parse();
 
     let since = since.map(|s| parse_timestamp(&s).unwrap());
     let until = until.map(|s| parse_timestamp(&s).unwrap());

--- a/sea-streamer-redis/src/bin/consumer.rs
+++ b/sea-streamer-redis/src/bin/consumer.rs
@@ -3,11 +3,11 @@ use sea_streamer_redis::{AutoStreamReset, RedisConsumerOptions, RedisStreamer};
 use sea_streamer_types::{
     Buffer, Consumer, ConsumerMode, ConsumerOptions, Message, StreamUrl, Streamer,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `redis://localhost/hello`",
         env = "STREAM_URL"
@@ -19,7 +19,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = RedisStreamer::connect(stream.streamer(), Default::default()).await?;
     let mut options = RedisConsumerOptions::new(ConsumerMode::RealTime);

--- a/sea-streamer-redis/src/bin/producer.rs
+++ b/sea-streamer-redis/src/bin/producer.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use sea_streamer_redis::RedisStreamer;
 use sea_streamer_types::{Producer, StreamUrl, Streamer};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer URI with stream key, i.e. try `redis://localhost/hello`",
         env = "STREAM_URL"
@@ -17,7 +17,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream } = Args::from_args();
+    let Args { stream } = Args::parse();
 
     let streamer = RedisStreamer::connect(stream.streamer(), Default::default()).await?;
     let mut producer = streamer

--- a/sea-streamer-socket/Cargo.toml
+++ b/sea-streamer-socket/Cargo.toml
@@ -23,13 +23,13 @@ sea-streamer-redis = { version = "0.3", path = "../sea-streamer-redis", optional
 sea-streamer-stdio = { version = "0.3", path = "../sea-streamer-stdio", optional = true }
 sea-streamer-file = { version = "0.3", path = "../sea-streamer-file", optional = true }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
-structopt = { version = "0.3", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
 thiserror = { version = "1", default-features = false }
 tokio = { version = "1.10.0", optional = true }
 
 [features]
 default = ["backend-stdio"] # sadly cannot compile without one backend
-executables = ["anyhow", "env_logger", "structopt", "tokio/full", "runtime-tokio"]
+executables = ["anyhow", "env_logger", "clap", "tokio/full", "runtime-tokio"]
 runtime-async-std = ["sea-streamer-kafka?/runtime-async-std", "sea-streamer-redis?/runtime-async-std", "sea-streamer-stdio?/runtime-async-std", "sea-streamer-file?/runtime-async-std"]
 runtime-tokio = ["sea-streamer-kafka?/runtime-tokio", "sea-streamer-redis?/runtime-tokio", "sea-streamer-stdio?/runtime-tokio", "sea-streamer-file?/runtime-tokio"]
 backend-kafka = ["sea-streamer-kafka"]

--- a/sea-streamer-socket/src/bin/relay.rs
+++ b/sea-streamer-socket/src/bin/relay.rs
@@ -4,23 +4,23 @@ use sea_streamer_types::{
     Consumer, ConsumerMode, ConsumerOptions, Message, Producer, StreamUrl, Streamer,
 };
 use std::str::FromStr;
-use structopt::StructOpt;
+use clap::Parser;
 
 #[cfg(feature = "backend-kafka")]
 use sea_streamer_kafka::AutoOffsetReset;
 #[cfg(feature = "backend-redis")]
 use sea_streamer_redis::AutoStreamReset;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(
+    #[clap(
         long,
         help = "Streamer Source Uri, i.e. try `kafka://localhost:9092/stream_key`"
     )]
     input: StreamUrl,
-    #[structopt(long, help = "Streamer Sink Uri, i.e. try `stdio:///stream_key`")]
+    #[clap(long, help = "Streamer Sink Uri, i.e. try `stdio:///stream_key`")]
     output: StreamUrl,
-    #[structopt(long, help = "Stream from `start` or `end`", default_value = "end")]
+    #[clap(long, help = "Stream from `start` or `end`", default_value = "end")]
     offset: Offset,
 }
 
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         input,
         output,
         offset,
-    } = Args::from_args();
+    } = Args::parse();
 
     if input == output && input.streamer().protocol() != Some("stdio") {
         bail!("input == output !!!");

--- a/sea-streamer-stdio/Cargo.toml
+++ b/sea-streamer-stdio/Cargo.toml
@@ -25,7 +25,7 @@ nom = { version = "7" }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime" }
 serde_json = { version = "1", optional = true }
-structopt = { version = "0.3", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
 thiserror = { version = "1", default-features = false }
 time = { version = "0.3", default-features = false, features = ["std", "parsing"] }
 tokio = { version = "1.10.0", optional = true }
@@ -35,7 +35,7 @@ tokio = { version = "1.10.0", optional = true }
 [features]
 default = []
 test = ["anyhow", "tokio/full", "env_logger", "sea-streamer-runtime/runtime-tokio"]
-executables = ["anyhow", "tokio/full", "env_logger", "structopt", "serde_json", "sea-streamer-types/json", "sea-streamer-runtime/runtime-tokio"]
+executables = ["anyhow", "tokio/full", "env_logger", "clap", "serde_json", "sea-streamer-types/json", "sea-streamer-runtime/runtime-tokio"]
 runtime-async-std = ["sea-streamer-runtime/runtime-async-std"]
 runtime-tokio = ["sea-streamer-runtime/runtime-tokio"]
 

--- a/sea-streamer-stdio/src/bin/clock.rs
+++ b/sea-streamer-stdio/src/bin/clock.rs
@@ -2,13 +2,13 @@ use anyhow::{anyhow, Result};
 use sea_streamer_stdio::StdioStreamer;
 use sea_streamer_types::{Producer, StreamKey, Streamer, StreamerUri};
 use std::time::Duration;
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream key")]
+    #[clap(long, help = "Stream key")]
     stream: StreamKey,
-    #[structopt(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
+    #[clap(long, parse(try_from_str = parse_duration), help = "Period of the clock. e.g. 1s, 100ms")]
     interval: Duration,
 }
 
@@ -32,7 +32,7 @@ fn parse_duration(src: &str) -> Result<Duration> {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { stream, interval } = Args::from_args();
+    let Args { stream, interval } = Args::parse();
 
     let streamer = StdioStreamer::connect(StreamerUri::zero(), Default::default()).await?;
     let producer = streamer.create_producer(stream, Default::default()).await?;

--- a/sea-streamer-stdio/src/bin/complex.rs
+++ b/sea-streamer-stdio/src/bin/complex.rs
@@ -6,13 +6,13 @@ use sea_streamer_types::{
     Consumer, ConsumerGroup, ConsumerMode, ConsumerOptions, Message, Producer, StreamKey, Streamer,
     StreamerUri,
 };
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream key of input")]
+    #[clap(long, help = "Stream key of input")]
     input: StreamKey,
-    #[structopt(long, help = "Stream key of output")]
+    #[clap(long, help = "Stream key of output")]
     output: StreamKey,
 }
 
@@ -20,7 +20,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = StdioStreamer::connect(StreamerUri::zero(), Default::default()).await?;
     let mut consumer_opt = StdioConsumerOptions::new(ConsumerMode::LoadBalanced);

--- a/sea-streamer-stdio/src/bin/relay.rs
+++ b/sea-streamer-stdio/src/bin/relay.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use sea_streamer_stdio::StdioStreamer;
 use sea_streamer_types::{Consumer, Message, Producer, StreamKey, Streamer, StreamerUri};
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Args {
-    #[structopt(long, help = "Stream key of input")]
+    #[clap(long, help = "Stream key of input")]
     input: StreamKey,
-    #[structopt(long, help = "Stream key of output")]
+    #[clap(long, help = "Stream key of output")]
     output: StreamKey,
 }
 
@@ -15,7 +15,7 @@ struct Args {
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let Args { input, output } = Args::from_args();
+    let Args { input, output } = Args::parse();
 
     let streamer = StdioStreamer::connect(StreamerUri::zero(), Default::default()).await?;
     let consumer = streamer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! async fn main() -> Result<()> {
 //!     env_logger::init();
 //!
-//!     let Args { stream } = Args::from_args();
+//!     let Args { stream } = Args::parse();
 //!
 //!     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 //!
@@ -76,7 +76,7 @@
 //! async fn main() -> Result<()> {
 //!     env_logger::init();
 //!
-//!     let Args { stream } = Args::from_args();
+//!     let Args { stream } = Args::parse();
 //!
 //!     let streamer = SeaStreamer::connect(stream.streamer(), Default::default()).await?;
 //!
@@ -105,7 +105,7 @@
 //! async fn main() -> Result<()> {
 //!     env_logger::init();
 //!
-//!     let Args { input, output } = Args::from_args();
+//!     let Args { input, output } = Args::parse();
 //!
 //!     let streamer = SeaStreamer::connect(input.streamer(), Default::default()).await?;
 //!     let options = SeaConsumerOptions::new(ConsumerMode::RealTime);


### PR DESCRIPTION
## PR Info

The `structopt` crate is in maintenance mode, see https://github.com/TeXitoi/structopt/issues/525. This PR replaces it with clap, as it is now directly implemented.