### PR TITLE
Update redis to 0.25

### DIFF
--- a/sea-streamer-redis/Cargo.toml
+++ b/sea-streamer-redis/Cargo.toml
@@ -23,7 +23,7 @@ flume = { version = "0.10", default-features = false, features = ["async"] }
 lazy_static = { version = "1.4" }
 log = { version = "0.4", default-features = false }
 mac_address = { version = "1" }
-redis = { version = "0.22", default-features = false, features = ["acl", "streams"] }
+redis = { version = "0.25", default-features = false, features = ["acl", "streams"] }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime" }
 structopt = { version = "0.3", optional = true }

--- a/sea-streamer-redis/Cargo.toml
+++ b/sea-streamer-redis/Cargo.toml
@@ -38,7 +38,7 @@ test = ["anyhow", "async-std?/attributes", "tokio?/full", "env_logger"]
 executables = ["anyhow", "env_logger", "structopt", "runtime-tokio", "tokio/full"]
 runtime-async-std = ["async-std", "redis/async-std-comp", "sea-streamer-runtime/runtime-async-std"]
 runtime-tokio = ["tokio", "redis/tokio-comp", "sea-streamer-runtime/runtime-tokio"]
-runtime-async-std-native-tls = ["runtime-async-std", "redis/async-std-tls-comp"]
+runtime-async-std-native-tls = ["runtime-async-std", "redis/async-std-native-tls-comp"]
 runtime-tokio-native-tls = ["runtime-tokio", "redis/tokio-native-tls-comp"]
 
 [[bin]]

--- a/sea-streamer-redis/src/consumer/node.rs
+++ b/sea-streamer-redis/src/consumer/node.rs
@@ -365,7 +365,10 @@ impl Node {
             && Timestamp::now_utc() - *self.options.auto_commit_interval() > self.group.last_commit
     }
 
-    async fn commit_ack(&mut self, conn: &mut redis::aio::Connection) -> RedisResult<()> {
+    async fn commit_ack(
+        &mut self,
+        conn: &mut redis::aio::MultiplexedConnection,
+    ) -> RedisResult<()> {
         for shard in self.shards.iter_mut() {
             if !shard.pending_ack.is_empty() {
                 match self.options.auto_commit() {
@@ -438,7 +441,10 @@ impl Node {
         }
     }
 
-    async fn read_next(&mut self, conn: &mut redis::aio::Connection) -> RedisResult<ReadResult> {
+    async fn read_next(
+        &mut self,
+        conn: &mut redis::aio::MultiplexedConnection,
+    ) -> RedisResult<ReadResult> {
         let mode = self.running_mode();
         if matches!(mode, ConsumerMode::Resumable | ConsumerMode::LoadBalanced)
             && self.group.first_read
@@ -601,7 +607,10 @@ impl Node {
         }
     }
 
-    async fn auto_claim(&mut self, conn: &mut redis::aio::Connection) -> RedisResult<ReadResult> {
+    async fn auto_claim(
+        &mut self,
+        conn: &mut redis::aio::MultiplexedConnection,
+    ) -> RedisResult<ReadResult> {
         self.group.last_check = Timestamp::now_utc();
         let change = self.group.claiming.is_none();
         if self.group.claiming.is_none() {
@@ -695,7 +704,10 @@ impl Node {
         }
     }
 
-    async fn move_shards(&mut self, conn: &mut redis::aio::Connection) -> Vec<StatusMsg> {
+    async fn move_shards(
+        &mut self,
+        conn: &mut redis::aio::MultiplexedConnection,
+    ) -> Vec<StatusMsg> {
         let mut events = Vec::new();
         let shards = std::mem::take(&mut self.shards);
         for shard in shards {


### PR DESCRIPTION
## PR Info

Updates redis to `0.25`, while it's been a year since the `0.23` release. It doesn't break the external interface. The only difference is raising MSVR to `1.65`, but the current module was already below `1.63` in `0.22` redis.

