### PR TITLE
Update rdkafka to 0.36

### DIFF
--- a/sea-streamer-kafka/Cargo.toml
+++ b/sea-streamer-kafka/Cargo.toml
@@ -21,7 +21,7 @@ async-std = { version = "1", optional = true }
 env_logger = { version = "0.9", optional = true }
 lazy_static = { version = "1.4" }
 mac_address = { version = "1" }
-rdkafka = { version = "0.29", default-features = false, features = ["libz"] }
+rdkafka = { version = "0.36", default-features = false, features = ["libz"] }
 sea-streamer-types = { version = "0.3", path = "../sea-streamer-types" }
 sea-streamer-runtime = { version = "0.3", path = "../sea-streamer-runtime" }
 structopt = { version = "0.3", optional = true }

--- a/sea-streamer-kafka/src/consumer.rs
+++ b/sea-streamer-kafka/src/consumer.rs
@@ -1,6 +1,6 @@
 use rdkafka::{
     config::ClientConfig,
-    consumer::{CommitMode, Consumer, MessageStream as RawMessageStream},
+    consumer::{CommitMode, Consumer, DefaultConsumerContext, MessageStream as RawMessageStream},
     message::BorrowedMessage as RawMessage,
     Message as KafkaMessageTrait, Offset, TopicPartitionList,
 };
@@ -78,18 +78,18 @@ pub enum AutoOffsetReset {
 
 /// Concrete type of Future that will yield the next message.
 pub type NextFuture<'a> = Map<
-    StreamFuture<RawMessageStream<'a>>,
+    StreamFuture<RawMessageStream<'a, DefaultConsumerContext>>,
     fn(
         (
             Option<Result<RawMessage<'a>, KafkaErr>>,
-            RawMessageStream<'a>,
+            RawMessageStream<'a, DefaultConsumerContext>,
         ),
     ) -> KafkaResult<KafkaMessage<'a>>,
 >;
 
 /// Concrete type of Stream that will yield the next messages.
 pub type KafkaMessageStream<'a> = StreamMap<
-    RawMessageStream<'a>,
+    RawMessageStream<'a, DefaultConsumerContext>,
     fn(Result<RawMessage<'a>, KafkaErr>) -> KafkaResult<KafkaMessage<'a>>,
 >;
 


### PR DESCRIPTION
## PR Info

Updates rdkafka to `0.36`, while it's been a year since the `0.29` release. It doesn't break the external interface.
